### PR TITLE
get the latest version of Azure Extension directly

### DIFF
--- a/DeepSecurityAddExtension_ARM_Linux_sample.ps1
+++ b/DeepSecurityAddExtension_ARM_Linux_sample.ps1
@@ -19,8 +19,8 @@ $publicFileContent = Get-Content -Raw -LiteralPath $publicFileName -Encoding UTF
 
 try{
 
-    $dsaExtVersionImages = Get-AzureRmVMExtensionImage -Location $location –PublisherName $dsaExtPublisher -Type $dsaExtName -ErrorAction Stop
-    $ver = $dsaExtVersionImages[$dsaExtVersionImages.Length-1].Version
+    $ver = Get-AzureRmVMExtensionImage -Location $location -PublisherName $dsaExtPublisher -Type $dsaExtName -ErrorAction Stop | Sort-Object -Property Version | Select-Object -Property Version -First 1
+    
     if( $ver -match "(\d+\.\d+)\.*") {  # get first two version-number (eg : get A.B from A.B.C.D)
         $ver = $Matches[1]
     }

--- a/DeepSecurityAddExtension_ARM_Windows_sample.ps1
+++ b/DeepSecurityAddExtension_ARM_Windows_sample.ps1
@@ -19,8 +19,8 @@ $publicFileContent = Get-Content -Raw -LiteralPath $publicFileName -Encoding UTF
 
 try{
 
-    $dsaExtVersionImages = Get-AzureRmVMExtensionImage -Location $location –PublisherName $dsaExtPublisher -Type $dsaExtName -ErrorAction Stop
-    $ver = $dsaExtVersionImages[$dsaExtVersionImages.Length-1].Version
+    $ver = Get-AzureRmVMExtensionImage -Location $location -PublisherName $dsaExtPublisher -Type $dsaExtName -ErrorAction Stop | Sort-Object -Property Version | Select-Object -Property Version -First 1
+
     if( $ver -match "(\d+\.\d+)\.*") {  # get first two version-number (eg : get A.B from A.B.C.D)
         $ver = $Matches[1]
     }


### PR DESCRIPTION
Currently there are 2 versions, 10.0 and 9.6, for Azure Extension. The original code doesn't sort the version so that user could get 9.6 for installation. User reports that he can't install 10.0 with the code so I update it to get the latest version.